### PR TITLE
Updater scripts for transforming HTML.

### DIFF
--- a/tools/figcaption-updater.awk
+++ b/tools/figcaption-updater.awk
@@ -12,7 +12,7 @@
 @include "html-metadata.awk"
 
 BEGIN {
-    RS = "</figure>"  # Iterate over links rathar than lines of text.
+    RS = "</figure>";  # Iterate over links rathar than lines of text.
     d = 0;  # debug
 }
 END { }
@@ -31,7 +31,7 @@ END { }
 	printf("%s", source); next;
     }
 
-    updated = source
+    updated = source;
 
     # Replace the HTML text in the <figcaption>; this happens unconditionally. 
     regexp    = "<figcaption>";

--- a/tools/figcaption-updater.awk
+++ b/tools/figcaption-updater.awk
@@ -1,0 +1,50 @@
+#!/usr/bin/awk -f
+#
+# This script updates <figcaption> HTML text to insert "Figure X-Y" in
+# front of the of existing caption, matching what's in the publinhed PDF.  
+#
+# Usage:
+# $ awk -f tools/figcaption-updater.awk -- raw/ch08.html
+# $ tools/find-html.sh | while read f; do awk -f tools/figcaption-updater.awk $f > $f.upd; done
+# $ tools/find-html.sh | while read f; do awk -f tools/figcaption-updater.awk $f > $f.upd; mv $f.upd $f; done
+
+# Expecting metadata to be in the local directory.
+@include "html-metadata.awk"
+
+BEGIN {
+    RS = "</figure>"  # Iterate over links rathar than lines of text.
+    d = 0;  # debug
+}
+END { }
+
+# Match blocks ending with the </figure>, so we can be sure to find <figcaption>.
+{
+    source = $0 RT  # We'll printf this verbatim when not updating the block. 
+
+    # Get the id= of the figure, so we can lookup metadata.
+    match(source, /\<figure id="([^"]+)"/, matches);
+    id = matches[1];
+    if (d > 1) { print "  figure id found: '" id "' in " source; print "O:"; print ""; } 
+    # Confirm we have the metadata.
+    if (!(id in metadata)) {
+	if (d) { print "  skipping figure id '" id "' not in metadata (OK when RT is empty: '" RT "')"; }
+	printf("%s", source); next;
+    }
+
+    updated = source
+
+    # Replace the HTML text in the <figcaption>; this happens unconditionally. 
+    regexp    = "<figcaption>";
+    text_updated = regexp metadata[id]["text"] ": ";
+    updated = gensub(regexp, text_updated, "g", updated);
+
+    # Replace the alt text in the <img>; this happens unconditionally. 
+    regexp    = "<img src=\"" metadata[id]["filename"] "\" alt=\"";
+    text_updated = regexp metadata[id]["text"] ": ";
+    updated = gensub(regexp, text_updated, "g", updated);
+    regexp    = "<img alt=\"";  # A more sloppy option for cases where src= comes last.
+    text_updated = regexp metadata[id]["text"] ": ";
+    updated = gensub(regexp, text_updated, "g", updated);
+
+    printf("%s", updated);
+}

--- a/tools/footnotes-updater.awk
+++ b/tools/footnotes-updater.awk
@@ -65,8 +65,10 @@ BEGINFILE {
 }
 
 ENDFILE {
-    print "<div data-type=\"footnotes\">";
-    for (i in footnotes) { print footnotes[i]; }
-    print "</div>";
+    if (length(footnotes)) {
+	print "<div data-type=\"footnotes\">";
+	for (i in footnotes) { print footnotes[i]; }
+	print "</div>";
+    }
 }
 

--- a/tools/footnotes-updater.awk
+++ b/tools/footnotes-updater.awk
@@ -11,19 +11,19 @@
 # This script doen't rely on @include "html-metadata.awk".
 
 BEGIN {
-    RS = "</span>"  # Iterate over footnote <span>.
+    RS = "</span>";  # Iterate over footnote <span>.
     d = 0;  # debug
 }
 
 BEGINFILE {
     # Footnote counters reset for each HTML file.
-    footnote_next = 1
+    footnote_next = 1;
     if (isarray(footnotes)) { delete footnotes; }
 }
 
 # Match blocks ending with the </span>, so we can be sure to find <figcaption>.
 {
-    source = $0 RT  # We'll printf this verbatim when not updating the block. 
+    source = $0 RT;  # We'll printf this verbatim when not updating the block.
 
     # Get the id of the footnote, otherwise skip this <span>.
     if (!match(source, /\<span data-type="footnote" id="([^"]+)"/, matches)) {
@@ -46,7 +46,7 @@ BEGINFILE {
 
     footnotes[footnote_next] = footnote;
     
-    updated = source
+    updated = source;
 
     # Replace the footnote HTML with the noteref HTML. 
     text_updated = regexp metadata[id]["text"] ": ";

--- a/tools/footnotes-updater.awk
+++ b/tools/footnotes-updater.awk
@@ -1,0 +1,72 @@
+#!/usr/bin/awk -f
+#
+# This script moves footnotes from their inlined positions to the bottom
+# of each file.
+#
+# Usage:
+# $ awk -f tools/footnotes-updater.awk -- raw/ch08.html
+# $ tools/find-html.sh | while read f; do awk -f tools/footnotes-updater.awk $f > $f.upd; done
+# $ tools/find-html.sh | while read f; do awk -f tools/footnotes-updater.awk $f > $f.upd; mv $f.upd $f; done
+
+# This script doen't rely on @include "html-metadata.awk".
+
+BEGIN {
+    RS = "</span>"  # Iterate over footnote <span>.
+    d = 0;  # debug
+}
+
+BEGINFILE {
+    # Footnote counters reset for each HTML file.
+    footnote_next = 1
+    if (isarray(footnotes)) { delete footnotes; }
+}
+
+# Match blocks ending with the </span>, so we can be sure to find <figcaption>.
+{
+    source = $0 RT  # We'll printf this verbatim when not updating the block. 
+
+    # Get the id of the footnote, otherwise skip this <span>.
+    if (!match(source, /\<span data-type="footnote" id="([^"]+)"/, matches)) {
+	if (d) { print "  skipping span without data-type=footnote (OK when RT is empty: '" RT "')"; }
+	printf("%s", source); next;
+    }
+    id = matches[1];
+
+    # Prepare the noteref that will go in place of the footnote.
+    noteref = sprintf("<sup><a data-type=\"noteref\" id=\"%s-marker\" href=\"#%s\">%s</a></sup>", id, id, footnote_next);
+    if (d > 1) { print "  noteref : " noteref; } 
+
+    # Find the footnote we'll be replacing with the noteref, but also editing and placing at HTML end.
+    span_regexp = sprintf("<span data-type=\"footnote\" id=\"%s\">(.+)</span>$", id);
+    match(source, span_regexp, matches);
+    span = matches[0];
+    text = matches[1];
+    footnote = sprintf("<p data-type=\"footnote\" id=\"%s\"><sup><a href=\"#%s-marker\">%s</a></sup>%s</p>", id, id, footnote_next, text);
+    if (d > 1) { print "  footnote: " footnote; } 
+
+    footnotes[footnote_next] = footnote;
+    
+    updated = source
+
+    # Replace the footnote HTML with the noteref HTML. 
+    text_updated = regexp metadata[id]["text"] ": ";
+    updated = gensub(span_regexp, noteref, "g", updated);
+
+    printf("%s", updated);
+
+    if (text ~ /\<span/) {
+	# WARNING: The span_regexp approach doesn't work for footnotes with
+	# <span> inside the footnote, but the book only few such footnotes,
+	# and it's cheaper to just fix them manually. Tag such places.
+	printf ("(FIXME:id=%s)", id);
+    }
+
+    footnote_next += 1;
+}
+
+ENDFILE {
+    print "<div data-type=\"footnotes\">";
+    for (i in footnotes) { print footnotes[i]; }
+    print "</div>";
+}
+

--- a/tools/href-updater.awk
+++ b/tools/href-updater.awk
@@ -12,19 +12,19 @@
 @include "html-metadata.awk"
 
 BEGIN {
-    RS = "</a>"  # Iterate over links rathar than lines of text.
+    RS = "</a>";  # Iterate over links rathar than lines of text.
     d = 0;  # debug
 }
 END { }
 
 # Lines end with the <a> whose closing </a> is stored in RT.
 {
-    source = $0 RT  # We'll printf this verbatim when not updating the block. 
+    source = $0 RT;  # We'll printf this verbatim when not updating the block.
 
     # Get just the <a>...</a>, for simplicity.
     match(source, /<a.+<\/a>/, matches);
-    a = matches[0]
-    if (d > 1) print "<a>: " a
+    a = matches[0];
+    if (d > 1) { print "<a>: " a; }
 
     # Get just the href= that point at #anchor (rather than anything else).
     match(a, /href=['"]#([^']+)['"]/, matches);
@@ -46,10 +46,10 @@ END { }
 	printf("%s", source); next;
     }
 
-    id = href  # A "rename", for convinience.
-    if (d) print "  found #" id " for updating " a
+    id = href;  # A "rename", for convinience.
+    if (d) { print "  found #" id " for updating " a; }
 
-    updated = source
+    updated = source;
 
     # First, an #anchor not to the local file needs to insert that file's name.
     # In the filename, omit any leading path since the HTML uses local directory references.

--- a/tools/toc-updater.awk
+++ b/tools/toc-updater.awk
@@ -1,0 +1,75 @@
+#!/usr/bin/awk -f
+#
+# This script generates HTML content for the book's TOC.
+#
+# Usage:
+# $ awk -f tools/toc-updater.awk --
+
+# Expecting metadata to be in the local directory.
+@include "html-metadata.awk"
+
+BEGIN {
+    d = 0;  # debug
+    print "<!DOCTYPE html>"
+    print "<html lang=\"en\">"
+    print "<head>"
+    print "  <meta charset=\"utf-8\">"
+    print "  <title>Building Secure and Reliable Systems</title>"
+    print "  <link rel=\"stylesheet\" type=\"text/css\" href=\"theme/html/html.css\">"
+    print "</head>"
+    print "<body data-type=\"book\">"
+    print "<nav xmlns=\"http://www.w3.org/1999/xhtml\" data-type=\"toc\"/>";
+
+    asort(metadata, ordered, "compare_by_order");
+
+    print "<ul>"
+    level = 0;
+    for (i in ordered) {
+	if (d) print " ** level=" level
+	type = ordered[i]["type"];
+	if (type ~ "sect") {
+	    if (type ~ "sect[12]") {
+		match(type, /[0-9]+/, matches);
+		level_new = (matches[0] + 0);
+	    } else {  # TOC omits sect3 and sect4, matching what's published.
+		continue
+	    }
+	} else if ("figure" == type) {
+	    continue
+	} else {
+	    level_new = 0
+	}
+	if (d) print " ** level_new=" level_new
+	while (level > level_new) {  # e.g. when level_new chapter follows level sect2.
+	    print "  </ul>";
+	    level = level - 1;
+	}
+	while (level < level_new) {  # e.g. when level_new sect2 follows level sect1.
+	    print "  <ul>";
+	    level = level + 1;
+	}
+	print "  <li data-type=\"" ordered[i]["type"] "\">"
+	print "    <a href=\"" ordered[i]["filename"] "#" ordered[i]["id"] "\">" ordered[i]["toc"] "</a>"
+	if (d) print "Order=" ordered[i]["order"]
+	print "  </li>"
+    }
+    print "</ul>"
+
+    print "</body>"
+    print "</html>"
+}
+
+END { }
+
+function compare_by_order(i1, v1, i2, v2, l, r)
+{
+    l = (v1["order"] + 0)
+    r = (v2["order"] + 0)
+
+    if (l < r)
+	return -1
+    else if (l == r)
+	return 0
+    else
+	return 1
+}

--- a/tools/toc-updater.awk
+++ b/tools/toc-updater.awk
@@ -10,6 +10,9 @@
 
 BEGIN {
     d = 0;  # debug
+
+    asort(metadata, ordered, "compare_by_order");
+
     print "<!DOCTYPE html>"
     print "<html lang=\"en\">"
     print "<head>"
@@ -20,26 +23,26 @@ BEGIN {
     print "<body data-type=\"book\">"
     print "<nav xmlns=\"http://www.w3.org/1999/xhtml\" data-type=\"toc\"/>";
 
-    asort(metadata, ordered, "compare_by_order");
-
+    # The loop below creates <li> within the global <ul>, and indents section
+    # headers within each file with additional levels of <ul>.
     print "<ul>"
     level = 0;
     for (i in ordered) {
-	if (d) print " ** level=" level
+	if (d) { print " ** level=" level ", order=" ordered[i]["order"]; }
 	type = ordered[i]["type"];
 	if (type ~ "sect") {
 	    if (type ~ "sect[12]") {
 		match(type, /[0-9]+/, matches);
 		level_new = (matches[0] + 0);
 	    } else {  # TOC omits sect3 and sect4, matching what's published.
-		continue
+		continue;
 	    }
 	} else if ("figure" == type) {
-	    continue
+	    continue;
 	} else {
-	    level_new = 0
+	    level_new = 0;
 	}
-	if (d) print " ** level_new=" level_new
+	if (d) { print " ** level_new=" level_new; }
 	while (level > level_new) {  # e.g. when level_new chapter follows level sect2.
 	    print "  </ul>";
 	    level = level - 1;
@@ -48,18 +51,15 @@ BEGIN {
 	    print "  <ul>";
 	    level = level + 1;
 	}
-	print "  <li data-type=\"" ordered[i]["type"] "\">"
-	print "    <a href=\"" ordered[i]["filename"] "#" ordered[i]["id"] "\">" ordered[i]["toc"] "</a>"
-	if (d) print "Order=" ordered[i]["order"]
-	print "  </li>"
+	print "  <li data-type=\"" ordered[i]["type"] "\">";
+	print "    <a href=\"" ordered[i]["filename"] "#" ordered[i]["id"] "\">" ordered[i]["toc"] "</a>";
+	print "  </li>";
     }
-    print "</ul>"
+    print "</ul>";
 
-    print "</body>"
-    print "</html>"
+    print "</body>";
+    print "</html>";
 }
-
-END { }
 
 function compare_by_order(i1, v1, i2, v2, l, r)
 {


### PR DESCRIPTION
- Make figure captions follow "Figure N-M" format.
- Move footnotes to the tail of each HTML file.
- Replace text in inter/intra-chapter hrefs, not to use "#id".
- Assemble a TOC matching what's in the published book.

HTML transformations will be added in separate commits.
