### PR TITLE
Adjust CSS to more closely match the printed book.

### DIFF
--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -169,6 +169,7 @@ div.toc-title {
 
 section[data-type="chapter"] h1, section[data-type="preface"] h1 { 
   font-size: 2.3em;
+  line-height: 1em;
   margin: 40px 0 15px 0;
 }
 

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -828,10 +828,6 @@ a.co img { padding: 0; }
 
 /* ----------------- html toc ----------------- */
 
-nav[data-type="toc"] li {
-  border: 0px solid #BEBEBE;  /* For debugging, set border non-zero. */
-}
-
 nav[data-type="toc"] li[data-type="foreword"] a,
 nav[data-type="toc"] li[data-type="preface"] a,
 nav[data-type="toc"] li[data-type="afterword"] a,

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -828,40 +828,37 @@ a.co img { padding: 0; }
 
 /* ----------------- html toc ----------------- */
 
-div.toc ol {
-  margin-top: 8px !important;
-  margin-bottom: 8px !important;
-  margin-left: 0px !important;
-  padding-left: 0px !important;
+nav[data-type="toc"] li {
+  border: 0px solid #BEBEBE;  /* For debugging, set border non-zero. */
 }
 
-div.toc ol ol {
-  margin-left: 30px !important;
-  padding-left: 0px !important;
-}
-
-div.toc ol li {
-  list-style-type: none;
-}
-
-div.toc a {
-  color: #8e0012;
-}
-
-div.toc ol a {
-  font-size: 1em;
+nav[data-type="toc"] li[data-type="foreword"] a,
+nav[data-type="toc"] li[data-type="preface"] a,
+nav[data-type="toc"] li[data-type="afterword"] a,
+nav[data-type="toc"] li[data-type="appendix"] a,
+nav[data-type="toc"] li[data-type="index"] a,
+nav[data-type="toc"] li[data-type="colophon"] a {
+  font-size: 1.1em;
   font-weight: bold;
 }
 
-div.toc ol > li > ol a {
+nav[data-type="toc"] li[data-type="part"] {
+  margin-top: 32px !important;
+  margin-bottom: 16px !important;
+}
+nav[data-type="toc"] li[data-type="part"] a {
+  font-size: 1.6em;
   font-weight: bold;
-  font-size: 1em;
 }
 
-div.toc ol > li > ol > li > ol a {
-  text-decoration: none;
-  font-weight: normal;
-  font-size: 1em;
+nav[data-type="toc"] li[data-type="chapter"] a {
+  font-size: 1.3em;
+  font-weight: bold;
+}
+
+/* Remove bullet discs/circles from top-lever items (but not sections). */
+nav[data-type="toc"] > ul > li {
+  list-style-type: none !important;
 }
 
 /* ----------------- admonitions ----------------- */

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -40,8 +40,9 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
   line-height: 1;
-        max-width: 34rem;
-        margin: 6.25rem;
+  /* Approximate the printed book's left indent and how the words split into lines. */
+  margin: 4.25rem;
+  max-width: 38rem;
 }
 ol, ul {
   list-style: none;
@@ -68,13 +69,13 @@ table {
 p { 
   margin: 10px 0 0;
   line-height: 125%;
-  text-align: left;
+  text-align: justify;  /* Approximate the printed book's appearance. */
 }
 
 /* author byline */
 p.byline {
-  text-align: left;
-  margin: 10px auto 0px;
+  text-align: right;
+  margin: 0px auto 0px;
   font-style: italic;
   font-weight: 400;
 }
@@ -247,6 +248,7 @@ div.figure {
 figure {
     margin: 15px auto !important;
     page-break-inside: avoid;
+    text-align: center;
 }
 
 div.figure h6,
@@ -284,8 +286,9 @@ aside[data-type="sidebar"] {
     margin: 15px 0px 10px 0px !important;
     page-break-inside: avoid;
     background-color: rgba(25, 25, 25, 0.05);
-    border-color: rgba(138, 130, 118, 0.1);
     padding: 0.75rem 0.75rem;
+    border: solid;
+    border-width: 1px;
 }
 
 div.sidebar-title, aside[data-type="sidebar"] h5 {

--- a/raw/toc.html
+++ b/raw/toc.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
-<nav xmlns="http://www.w3.org/1999/xhtml" data-type="toc"/>
+<nav xmlns="http://www.w3.org/1999/xhtml" data-type="toc">
 <ul>
   <li data-type="foreword">
     <a href="foreword01.html#foreword">Foreword by Royal Hansen</a>
@@ -1398,5 +1398,6 @@
     <a href="author_bio.html#about_the_editors">About the Editors</a>
   </li>
 </ul>
+</nav>
 </body>
 </html>


### PR DESCRIPTION
For all content:
  - Fix chapter title texts overlapping in multi-line.
  - Adjust the overall visible width and text aligment.
  - Align bylines to the right.
  - Align images to center.
  - Add border for asides at the start of chapters.

For the TOC:
  - Bold and resize top-level items.
  - Space out each Part.
  - Delete unused CSS from the TOC section.