### PR TITLE
Fix CSS: indexterm's distracting whitespace, footnotes text sizes, h1 for non-chapters.

### DIFF
--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -168,6 +168,14 @@ div.toc-title {
   margin-bottom: 30px !important;
 }
 
+/* This h2 subtitle *sometimes* precedes the section>h1 elements below. */
+h2.section-subtitle {
+  font-size: 1.3em;
+  line-height: 1em;
+  /* Use -20px to compensate the 40px gap the h1 that always follows must set. */
+  margin: 40px 0 -20px 0;
+}
+
 nav[data-type="toc"] h1,
 section[data-type="dedication"] h1,
 section[data-type="foreword"] h1,

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -629,15 +629,6 @@ p.right {
 
 /* ----------------- footnotes ----------------- */
 
-div[data-type="footnotes"] {
-  border-top: 1px solid black;
-  margin-top: 2em;
-}
-
-div[data-type="footnotes"] a {
-    /* Ensure the link text size matches the non-link text size. */
-}
-
 sub, sup {
   font-size: 75%;
   line-height: 0;
@@ -647,6 +638,17 @@ sub, sup {
 sup { top: -0.5em; }
 
 sub { bottom: -0.25em; }
+
+div[data-type="footnotes"] {
+  border-top: 1px solid black;
+  margin-top: 2em;
+}
+
+/* Ensure various element types (a, em, code) match the text
+   size adjustments defined below in p[data-type="footnote"]. */
+div[data-type="footnotes"] * {
+    font-size: 90% !important;
+}
 
 p[data-type="footnote"] {
     font-size: 90% !important;
@@ -1175,7 +1177,7 @@ div.informalequation img {
 
 /* The indexterm <a> are sprinkled everywhere, for backreferencing from
    the index (ix.html), but their &nbsp; inserts distracting whitespace. */
-a[id="indexterm] {
+a[data-type="indexterm"] {
   display: inline-block !important;
   width: 0px !important;
 }

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -168,7 +168,13 @@ div.toc-title {
   margin-bottom: 30px !important;
 }
 
-section[data-type="chapter"] h1, section[data-type="preface"] h1 { 
+section[data-type="foreword"] h1,
+section[data-type="preface"] h1,
+section[data-type="chapter"] h1,
+section[data-type="afterword"] h1,
+section[data-type="appendix"] h1,
+section[data-type="colophon"] h1,
+section[data-type="index"] h1 {
   font-size: 2.3em;
   line-height: 1em;
   margin: 40px 0 15px 0;

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -661,9 +661,11 @@ div[data-type="footnotes"] {
 }
 
 /* Ensure various element types (a, em, code) match the text
-   size adjustments defined below in p[data-type="footnote"]. */
+   size adjustments defined below in p[data-type="footnote"].
+   Don't use central alignment, to match the published format. */
 div[data-type="footnotes"] * {
     font-size: 90% !important;
+    text-align: left !important;
 }
 
 p[data-type="footnote"] {

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -1169,6 +1169,13 @@ div.informalequation img {
 
 /* ----------------- index ----------------- */
 
+/* The indexterm <a> are sprinkled everywhere, for backreferencing from
+   the index (ix.html), but their &nbsp; inserts distracting whitespace. */
+a[id="indexterm] {
+  display: inline-block !important;
+  width: 0px !important;
+}
+
 div.index {
   text-indent: 0;
 }

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -634,6 +634,10 @@ div[data-type="footnotes"] {
   margin-top: 2em;
 }
 
+div[data-type="footnotes"] a {
+    /* Ensure the link text size matches the non-link text size. */
+}
+
 sub, sup {
   font-size: 75%;
   line-height: 0;

--- a/raw/theme/html/html.css
+++ b/raw/theme/html/html.css
@@ -168,6 +168,8 @@ div.toc-title {
   margin-bottom: 30px !important;
 }
 
+nav[data-type="toc"] h1,
+section[data-type="dedication"] h1,
 section[data-type="foreword"] h1,
 section[data-type="preface"] h1,
 section[data-type="chapter"] h1,
@@ -840,6 +842,7 @@ a.co img { padding: 0; }
 
 /* ----------------- html toc ----------------- */
 
+nav[data-type="toc"] li[data-type="dedication"] a,
 nav[data-type="toc"] li[data-type="foreword"] a,
 nav[data-type="toc"] li[data-type="preface"] a,
 nav[data-type="toc"] li[data-type="afterword"] a,


### PR DESCRIPTION
- Hide whitespace from indexterms, without removing them.
- Make inconsistently larger a, em, and code match font size in footnotes.
- Match h1 styling for files that aren't preface or chapters.