### PR TITLE
Insert "Chapter X" as title prefix and heading.

### DIFF
--- a/raw/appa.html
+++ b/raw/appa.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Appendix: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Appendix</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="appendix" id="a_disaster_risk_assessment_matrix">
 <h1>A Disaster Risk Assessment Matrix</h1>
 <p><a contenteditable="false" data-primary="disaster risk analysis" data-type="indexterm" id="appa.html_ix1">&nbsp;</a><a contenteditable="false" data-primary="risk analysis" data-type="indexterm" id="appa.html_ix2">&nbsp;</a><a contenteditable="false" data-primary="risk assessment" data-secondary="disaster risk assessment matrix" data-type="indexterm" id="appa.html_ix3">&nbsp;</a>For a thorough disaster risk analysis, we recommend ranking the risks facing your organization by using a standardized matrix that accounts for each risk’s probability of occurrence and its potential impact to the organization. <a data-type="xref" href="#sample_disaster_risk_assessment_matrix">#sample_disaster_risk_assessment_matrix</a> is a sample risk assessment matrix that both large and small organizations can tailor to the specifics of their systems. </p>

--- a/raw/author_bio.html
+++ b/raw/author_bio.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Editors: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/ch01.html
+++ b/raw/ch01.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 1: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 1</h2>
 <section data-type="chapter" id="the_intersection_of_security_and_reliab" xmlns="http://www.w3.org/1999/xhtml">
 <h1>The Intersection of Security and Reliability</h1>
 

--- a/raw/ch02.html
+++ b/raw/ch02.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 2: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 2</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="understanding_adversaries">
 <h1>Understanding Adversaries</h1>
 

--- a/raw/ch03.html
+++ b/raw/ch03.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 3: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 3</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="case_study_safe_proxies">
 <h1>Case Study: Safe Proxies</h1>
 

--- a/raw/ch04.html
+++ b/raw/ch04.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 4: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 4</h2>
 <section data-type="chapter" id="design_tradeoffs" xmlns="http://www.w3.org/1999/xhtml">
 <h1>Design Tradeoffs</h1>
 

--- a/raw/ch05.html
+++ b/raw/ch05.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 5: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 5</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="design_for_least_privilege">
 <h1>Design for Least Privilege</h1>
 

--- a/raw/ch06.html
+++ b/raw/ch06.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 6: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 6</h2>
 <section data-type="chapter" id="design_for_understandability" xmlns="http://www.w3.org/1999/xhtml">
 <h1>Design for Understandability</h1>
 

--- a/raw/ch07.html
+++ b/raw/ch07.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 7: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 7</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="design_for_a_changing_landscape">
 <h1>Design for a Changing Landscape</h1>
 

--- a/raw/ch08.html
+++ b/raw/ch08.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 8: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 8</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="design_for_resilience">
 <h1>Design for Resilience</h1>
 

--- a/raw/ch09.html
+++ b/raw/ch09.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 9: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 9</h2>
 <section data-type="chapter" id="design_for_recovery" xmlns="http://www.w3.org/1999/xhtml">
 <h1>Design for Recovery</h1>
 

--- a/raw/ch10.html
+++ b/raw/ch10.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 10: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 10</h2>
 <section data-type="chapter" id="mitigating_denial_of_service_attacks" xmlns="http://www.w3.org/1999/xhtml">
 <h1>Mitigating Denial-of-Service Attacks</h1>
 

--- a/raw/ch11.html
+++ b/raw/ch11.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 11: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 11</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="case_study_designingcomma_implementi">
 <h1>Case Study: Designing, Implementing, and Maintaining a Publicly Trusted CA</h1>
 

--- a/raw/ch12.html
+++ b/raw/ch12.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 12: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 12</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="writing_code">
 <h1>Writing Code</h1>
 

--- a/raw/ch13.html
+++ b/raw/ch13.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 13: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 13</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="onethree_testing_code">
 <h1>Testing Code</h1>
 

--- a/raw/ch14.html
+++ b/raw/ch14.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 14: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 14</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="onefour_deploying_code">
 <h1>Deploying Code</h1>
 

--- a/raw/ch15.html
+++ b/raw/ch15.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 15: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 15</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="onefive_investigating_systems">
 <h1>Investigating Systems</h1>
 

--- a/raw/ch16.html
+++ b/raw/ch16.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 16: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 16</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="onesix_disaster_planning">
 <h1>Disaster Planning</h1>
 

--- a/raw/ch17.html
+++ b/raw/ch17.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 17: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 17</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="oneseven_crisis_management">
 <h1>Crisis Management</h1>
 

--- a/raw/ch18.html
+++ b/raw/ch18.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 18: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 18</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="oneeight_recovery_and_aftermath">
 <h1>Recovery and Aftermath</h1>
 

--- a/raw/ch19.html
+++ b/raw/ch19.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 19: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 19</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="onenine_case_study_chrome_security_team">
 <h1>Case Study: Chrome Security Team</h1>
 

--- a/raw/ch20.html
+++ b/raw/ch20.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 20: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 20</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="twozero_understanding_roles_and_respons">
 <h1>Understanding Roles and Responsibilities</h1>
 

--- a/raw/ch21.html
+++ b/raw/ch21.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Chapter 21: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Chapter 21</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="chapter" id="twoone_building_a_culture_of_security_a">
 <h1>Building a Culture of Security and Reliability</h1>
 

--- a/raw/ch22.html
+++ b/raw/ch22.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Conclusion: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/dedication.html
+++ b/raw/dedication.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Dedication: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/foreword01.html
+++ b/raw/foreword01.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Foreword: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/foreword02.html
+++ b/raw/foreword02.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Foreword: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/ix.html
+++ b/raw/ix.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Index: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/part1.html
+++ b/raw/part1.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Part I: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Part I</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="part" class="pagenumrestart" id="introductory_material">
 <h1>Introductory Material</h1>
 <p>If you asked your customers to name their favorite features of your products, it’s unlikely that their lists would begin with security and reliability. Both features are often hidden in their expectations: if they’re working well, your customers don’t notice them.</p>

--- a/raw/part2.html
+++ b/raw/part2.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Part II: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Part II</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="part" id="designing_systems">
 <h1>Designing Systems</h1>
 <p><a data-type="xref" href="#designing_systems">Part II</a> focuses on the most cost-effective way to implement security and reliability requirements: as early as possible in the software development lifecycle, when designing systems.</p>

--- a/raw/part3.html
+++ b/raw/part3.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Part III: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Part III</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="part" id="implementing_systems">
 <h1>Implementing Systems</h1>
 <p>Once you’ve analyzed and designed your systems, it’s time to implement your plans. In some cases, implementation might mean buying an off-the-shelf solution. <a data-type="xref" href='ch11.html#case_study_designingcomma_implementi'>Chapter 11</a> provides one example of Google’s thought process in deciding to build a custom software solution.</p>

--- a/raw/part4.html
+++ b/raw/part4.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Part IV: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Part IV</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="part" id="maintaining_systems">
 <h1>Maintaining Systems</h1>
 <p>Organizations that are prepared to cope with uncomfortable situations have a better chance of dealing with a critical incident.</p>

--- a/raw/part5.html
+++ b/raw/part5.html
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Part V: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
+<h2 class="section-subtitle">Part V</h2>
 <section xmlns="http://www.w3.org/1999/xhtml" data-type="part" id="organization_and_culture">
 <h1>Organization and Culture</h1>
 <p>While the engineering practices highlighted in this book will help your organization build secure and reliable systems, your efforts will be effective only if your entire organization is invested in a culture of security and reliability. Culture is a powerful and unique defining component of every organization, and you should not underestimate its role in your ability to institute change.</p>

--- a/raw/pr01.html
+++ b/raw/pr01.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Preface: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">

--- a/raw/praise.html
+++ b/raw/praise.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Building Secure and Reliable Systems</title>
+  <title>Praise: Building Secure and Reliable Systems</title>
   <link rel="stylesheet" type="text/css" href="theme/html/html.css">
 </head>
 <body data-type="book">
 <section data-type="dedication" class="praise pagenumrestart">
-<h1>Praise for <em>Building Secure and Reliable Systems</em></h1>
+<h1>Praise for "Building Secure and Reliable Systems"</h1>
 
 
 <blockquote>

--- a/raw/toc.html
+++ b/raw/toc.html
@@ -7,7 +7,12 @@
 </head>
 <body data-type="book">
 <nav xmlns="http://www.w3.org/1999/xhtml" data-type="toc">
+<h1>Table of Contents</h1>
+<p class="byline">&nbsp;</p>
 <ul>
+  <li data-type="dedication">
+    <a href="praise.html">Praise</a> and <a href="dedication.html">Dedication</a>
+  </li>
   <li data-type="foreword">
     <a href="foreword01.html#foreword">Foreword by Royal Hansen</a>
   </li>

--- a/tools/toc-updater.awk
+++ b/tools/toc-updater.awk
@@ -21,11 +21,20 @@ BEGIN {
     print "  <link rel=\"stylesheet\" type=\"text/css\" href=\"theme/html/html.css\">"
     print "</head>"
     print "<body data-type=\"book\">"
-    print "<nav xmlns=\"http://www.w3.org/1999/xhtml\" data-type=\"toc\"/>";
+    print "<nav xmlns=\"http://www.w3.org/1999/xhtml\" data-type=\"toc\">";
+    print "<h1>Table of Contents</h1>";
+    print "<p class=\"byline\">&nbsp;</p>";  # For vertical spacing consistent with other files.
 
     # The loop below creates <li> within the global <ul>, and indents section
     # headers within each file with additional levels of <ul>.
     print "<ul>"
+
+    # Combine in this first static entry the two recognition pages the paper
+    # book has before the TOC, so they weren't listed in the printed TOC.   
+    print "  <li data-type=\"dedication\">";
+    print "    <a href=\"praise.html\">Praise</a> and <a href=\"dedication.html\">Dedication</a>";
+    print "  </li>";
+    
     level = 0;
     for (i in ordered) {
 	if (d) { print " ** level=" level ", order=" ordered[i]["order"]; }
@@ -57,6 +66,7 @@ BEGIN {
     }
     print "</ul>";
 
+    print "</nav>";
     print "</body>";
     print "</html>";
 }


### PR DESCRIPTION
This makes it easier to tell the chapter number
when viewing a chapter's paget (content). This
also helps differentiate chapters loaded into
multiple browser tabs.

Tools changes only for TOC. The main changes
manual (with minimal `sed` assistance).
